### PR TITLE
Add optional Unsloth optimisations

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,7 @@ See `active-ic-llm/README.md` for details on how to install dependencies, prepar
 
 The codebase optionally integrates the [unsloth.ai](https://www.unsloth.ai) library
 for faster model loading when the `--use_unsloth` flag is supplied.
+
+Prepared datasets span multiple benchmarks including math reasoning
+(e.g. GSM8k, AQUA-RAT), commonsense QA (BoolQ, HellaSwag, ARC, Winogrande, PiQA
+and others) and instruction following evaluations such as DollyEval and VicunaEval.

--- a/README.md
+++ b/README.md
@@ -5,3 +5,6 @@ This repository provides an implementation of **ActiveLLM**, a large language mo
 The code is organised as a Python package under `active-ic-llm` and contains scripts for dataset preparation, running experiments with different active learning strategies and models, and utilities for embeddings and clustering.
 
 See `active-ic-llm/README.md` for details on how to install dependencies, prepare data and reproduce the experiments.
+
+The codebase optionally integrates the [unsloth.ai](https://www.unsloth.ai) library
+for faster model loading when the `--use_unsloth` flag is supplied.

--- a/active-ic-llm/README.md
+++ b/active-ic-llm/README.md
@@ -2,7 +2,7 @@
 
 This directory contains the implementation of ActiveLLM. It is organised into several modules:
 
-- `data_preprocessing/` — scripts for downloading and preparing CrossFit datasets.
+- `data_preprocessing/` — scripts for downloading and preparing datasets, including CrossFit tasks, math reasoning benchmarks, commonsense QA and instruction following corpora.
 - `src/` — core package containing configuration loading, dataset classes, prompt builders and active learning strategies.
 - `experiments/` — helper scripts for running batch experiments across tasks.
 - `docs/` — additional documentation including a design overview.
@@ -12,13 +12,11 @@ This directory contains the implementation of ActiveLLM. It is organised into se
 ```bash
 pip install -r requirements.txt
 ```
-To enable optional training and inference optimisations using
-[unsloth.ai](https://www.unsloth.ai), install the extra dependency and pass the
-`--use_unsloth` flag when running experiments.
+To enable optional training and inference optimisations using [unsloth.ai](https://www.unsloth.ai), install the package and pass the `--use_unsloth` flag when running experiments. To avoid pulling heavy dependencies you may run `pip install --no-deps unsloth`.
 
 ## Preparing Data
 
-Run the preprocessing scripts to download and standardise the CrossFit datasets:
+Run the preprocessing scripts to download and standardise the datasets mentioned above:
 
 ```bash
 python data_preprocessing/download_datasets.py

--- a/active-ic-llm/README.md
+++ b/active-ic-llm/README.md
@@ -12,6 +12,9 @@ This directory contains the implementation of ActiveLLM. It is organised into se
 ```bash
 pip install -r requirements.txt
 ```
+To enable optional training and inference optimisations using
+[unsloth.ai](https://www.unsloth.ai), install the extra dependency and pass the
+`--use_unsloth` flag when running experiments.
 
 ## Preparing Data
 

--- a/active-ic-llm/config.yaml
+++ b/active-ic-llm/config.yaml
@@ -11,3 +11,4 @@ outputs_dir: outputs
 max_seq_length: 128
 seed: 42
 device: cpu
+use_unsloth: false

--- a/active-ic-llm/config.yaml
+++ b/active-ic-llm/config.yaml
@@ -2,8 +2,11 @@ model_name: bert-base-uncased
 al_method: random
 num_shots: 8
 pool_fraction: 0.2
-classification_tasks: ["sst2"]
-multichoice_tasks: ["hellaswag"]
+classification_tasks: ["sst2", "boolq"]
+multichoice_tasks: ["hellaswag", "arc-c", "arc-e", "winogrande", "piqa", "siqa", "obqa"]
+commonsense_tasks: ["hellaswag", "arc-c", "arc-e", "winogrande", "piqa", "siqa", "obqa"]
+math_reasoning_tasks: ["gsm8k", "aqua_rat", "addsub", "multiarith", "singleeq", "svamp"]
+instruction_following_tasks: ["dolly_eval", "vicuna_eval", "self_instruct", "s_ni", "un_ni"]
 data_dir: data
 standardized_dir: data/standardized
 raw_dir: data/raw

--- a/active-ic-llm/data_preprocessing/download_datasets.py
+++ b/active-ic-llm/data_preprocessing/download_datasets.py
@@ -8,9 +8,33 @@ from pathlib import Path
 CATEGORIES = {
     "classification": [
         "sst2",
+        # Commonsense QA style binary classification
+        "boolq",
     ],
     "multichoice": [
         "hellaswag",
+        "arc-c",
+        "arc-e",
+        "winogrande",
+        "piqa",
+        "siqa",
+        "obqa",
+    ],
+    # Additional categories used for experimentation
+    "math_reasoning": [
+        "gsm8k",
+        "aqua_rat",
+        "addsub",
+        "multiarith",
+        "singleeq",
+        "svamp",
+    ],
+    "instruction_following": [
+        "dolly_eval",
+        "vicuna_eval",
+        "self_instruct",
+        "s_ni",
+        "un_ni",
     ],
 }
 

--- a/active-ic-llm/data_preprocessing/prepare_crossfit.py
+++ b/active-ic-llm/data_preprocessing/prepare_crossfit.py
@@ -17,7 +17,7 @@ def prepare_classification(records) -> pd.DataFrame:
         {
             "id": range(len(records)),
             "text": [r.get("text", r.get("question", "")) for r in records],
-            "label": [r.get("label") for r in records],
+            "label": [r.get("label", r.get("answer")) for r in records],
         }
     )
 

--- a/active-ic-llm/experiments/classification_exp.py
+++ b/active-ic-llm/experiments/classification_exp.py
@@ -10,15 +10,21 @@ def main():
     parser.add_argument("--num_shots", type=int)
     args = parser.parse_args()
 
-    for task in cfg.classification_tasks:
-        cmd = ["python", "src/run_experiment.py", "--task", task]
-        if args.model_name:
-            cmd += ["--model_name", args.model_name]
-        if args.al_method:
-            cmd += ["--al_method", args.al_method]
-        if args.num_shots is not None:
-            cmd += ["--num_shots", str(args.num_shots)]
-        call(cmd)
+    task_lists = [
+        cfg.classification_tasks,
+        cfg.get("math_reasoning_tasks", []),
+        cfg.get("instruction_following_tasks", []),
+    ]
+    for task_list in task_lists:
+        for task in task_list:
+            cmd = ["python", "src/run_experiment.py", "--task", task]
+            if args.model_name:
+                cmd += ["--model_name", args.model_name]
+            if args.al_method:
+                cmd += ["--al_method", args.al_method]
+            if args.num_shots is not None:
+                cmd += ["--num_shots", str(args.num_shots)]
+            call(cmd)
 
 
 if __name__ == "__main__":

--- a/active-ic-llm/experiments/multichoice_exp.py
+++ b/active-ic-llm/experiments/multichoice_exp.py
@@ -10,15 +10,20 @@ def main():
     parser.add_argument("--num_shots", type=int)
     args = parser.parse_args()
 
-    for task in cfg.multichoice_tasks:
-        cmd = ["python", "src/run_experiment.py", "--task", task]
-        if args.model_name:
-            cmd += ["--model_name", args.model_name]
-        if args.al_method:
-            cmd += ["--al_method", args.al_method]
-        if args.num_shots is not None:
-            cmd += ["--num_shots", str(args.num_shots)]
-        call(cmd)
+    task_lists = [
+        cfg.multichoice_tasks,
+        cfg.get("commonsense_tasks", []),
+    ]
+    for task_list in task_lists:
+        for task in task_list:
+            cmd = ["python", "src/run_experiment.py", "--task", task]
+            if args.model_name:
+                cmd += ["--model_name", args.model_name]
+            if args.al_method:
+                cmd += ["--al_method", args.al_method]
+            if args.num_shots is not None:
+                cmd += ["--num_shots", str(args.num_shots)]
+            call(cmd)
 
 
 if __name__ == "__main__":

--- a/active-ic-llm/requirements.txt
+++ b/active-ic-llm/requirements.txt
@@ -5,4 +5,4 @@ datasets
 scikit-learn
 pyyaml
 pandas
-unsloth
+unsloth  # optional speedups

--- a/active-ic-llm/requirements.txt
+++ b/active-ic-llm/requirements.txt
@@ -5,3 +5,4 @@ datasets
 scikit-learn
 pyyaml
 pandas
+unsloth

--- a/active-ic-llm/src/models/model_utils.py
+++ b/active-ic-llm/src/models/model_utils.py
@@ -3,14 +3,28 @@
 from typing import List
 import torch
 from transformers import AutoTokenizer, AutoModelForCausalLM
+
+try:
+    from unsloth.models import FastLanguageModel
+    _HAS_UNSLOTH = True
+except Exception:
+    _HAS_UNSLOTH = False
 import math
 
 
 class ModelUtils:
-    def __init__(self, model_name: str, device: str = "cpu"):
-        self.tokenizer = AutoTokenizer.from_pretrained(model_name)
-        self.model = AutoModelForCausalLM.from_pretrained(model_name).to(device)
+    def __init__(self, model_name: str, device: str = "cpu", use_unsloth: bool = False):
         self.device = device
+        if use_unsloth and _HAS_UNSLOTH:
+            self.model, self.tokenizer = FastLanguageModel.from_pretrained(
+                model_name,
+                device_map="auto",
+                use_gradient_checkpointing=False,
+            )
+            self.model = self.model.to(device)
+        else:
+            self.tokenizer = AutoTokenizer.from_pretrained(model_name)
+            self.model = AutoModelForCausalLM.from_pretrained(model_name).to(device)
 
     def compute_perplexity(self, text: str) -> float:
         inputs = self.tokenizer(text, return_tensors="pt").to(self.device)

--- a/active-ic-llm/src/run_experiment.py
+++ b/active-ic-llm/src/run_experiment.py
@@ -25,11 +25,11 @@ def get_sampler(name: str):
     raise ValueError(f"Unknown sampler {name}")
 
 
-def run(task: str, al_method: str, model_name: str, num_shots: int) -> None:
+def run(task: str, al_method: str, model_name: str, num_shots: int, use_unsloth: bool) -> None:
     pool_dataset = CrossFitDataset(task, "pool")
     test_dataset = CrossFitDataset(task, "test")
     sampler = get_sampler(al_method)
-    mu = ModelUtils(model_name, device=cfg.device)
+    mu = ModelUtils(model_name, device=cfg.device, use_unsloth=use_unsloth)
     label_space = sorted(set(pool_dataset.get_all_labels()))
 
     if al_method != "similarity":
@@ -92,9 +92,10 @@ def main():
     parser.add_argument("--al_method", default=cfg.al_method)
     parser.add_argument("--model_name", default=cfg.model_name)
     parser.add_argument("--num_shots", type=int, default=cfg.num_shots)
+    parser.add_argument("--use_unsloth", action="store_true", default=cfg.use_unsloth)
     args = parser.parse_args()
 
-    run(args.task, args.al_method, args.model_name, args.num_shots)
+    run(args.task, args.al_method, args.model_name, args.num_shots, args.use_unsloth)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add `unsloth` to requirements and config
- support loading models via Unsloth in `ModelUtils`
- expose `--use_unsloth` argument in experiment runner
- document Unsloth usage in READMEs

## Testing
- `python -m py_compile active-ic-llm/src/models/model_utils.py active-ic-llm/src/run_experiment.py active-ic-llm/src/config.py`

------
https://chatgpt.com/codex/tasks/task_e_6846ac16b72c8320aa71dde9bc33745d