### PR TITLE
Allow disabling Unsloth from CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ The code is organised as a Python package under `active-ic-llm` and contains scr
 See `active-ic-llm/README.md` for details on how to install dependencies, prepare data and reproduce the experiments.
 
 The codebase optionally integrates the [unsloth.ai](https://www.unsloth.ai) library
-for faster model loading when the `--use_unsloth` flag is supplied.
+for faster model loading when the `--use_unsloth` flag is supplied. You can
+explicitly disable it by passing `--no-use_unsloth` on the command line.
 
 Prepared datasets span multiple benchmarks including math reasoning
 (e.g. GSM8k, AQUA-RAT), commonsense QA (BoolQ, HellaSwag, ARC, Winogrande, PiQA

--- a/active-ic-llm/README.md
+++ b/active-ic-llm/README.md
@@ -12,7 +12,7 @@ This directory contains the implementation of ActiveLLM. It is organised into se
 ```bash
 pip install -r requirements.txt
 ```
-To enable optional training and inference optimisations using [unsloth.ai](https://www.unsloth.ai), install the package and pass the `--use_unsloth` flag when running experiments. To avoid pulling heavy dependencies you may run `pip install --no-deps unsloth`.
+To enable optional training and inference optimisations using [unsloth.ai](https://www.unsloth.ai), install the package and pass the `--use_unsloth` flag when running experiments. These optimisations can be turned off with `--no-use_unsloth`. To avoid pulling heavy dependencies you may run `pip install --no-deps unsloth`.
 
 ## Preparing Data
 

--- a/active-ic-llm/src/models/model_utils.py
+++ b/active-ic-llm/src/models/model_utils.py
@@ -4,27 +4,34 @@ from typing import List
 import torch
 from transformers import AutoTokenizer, AutoModelForCausalLM
 
-try:
-    from unsloth.models import FastLanguageModel
-    _HAS_UNSLOTH = True
-except Exception:
-    _HAS_UNSLOTH = False
+_HAS_UNSLOTH = False
+FastLanguageModel = None
 import math
 
 
 class ModelUtils:
     def __init__(self, model_name: str, device: str = "cpu", use_unsloth: bool = False):
         self.device = device
-        if use_unsloth and _HAS_UNSLOTH:
-            self.model, self.tokenizer = FastLanguageModel.from_pretrained(
-                model_name,
-                device_map="auto",
-                use_gradient_checkpointing=False,
-            )
-            self.model = self.model.to(device)
-        else:
-            self.tokenizer = AutoTokenizer.from_pretrained(model_name)
-            self.model = AutoModelForCausalLM.from_pretrained(model_name).to(device)
+        if use_unsloth:
+            global _HAS_UNSLOTH, FastLanguageModel
+            if not _HAS_UNSLOTH:
+                try:
+                    from unsloth.models import FastLanguageModel as _FLM
+                    FastLanguageModel = _FLM
+                    _HAS_UNSLOTH = True
+                except Exception:
+                    _HAS_UNSLOTH = False
+            if _HAS_UNSLOTH:
+                self.model, self.tokenizer = FastLanguageModel.from_pretrained(
+                    model_name,
+                    device_map="auto",
+                    use_gradient_checkpointing=False,
+                )
+                self.model = self.model.to(device)
+                return
+        # fall back to standard transformers loader
+        self.tokenizer = AutoTokenizer.from_pretrained(model_name)
+        self.model = AutoModelForCausalLM.from_pretrained(model_name).to(device)
 
     def compute_perplexity(self, text: str) -> float:
         inputs = self.tokenizer(text, return_tensors="pt").to(self.device)

--- a/active-ic-llm/src/run_experiment.py
+++ b/active-ic-llm/src/run_experiment.py
@@ -92,7 +92,12 @@ def main():
     parser.add_argument("--al_method", default=cfg.al_method)
     parser.add_argument("--model_name", default=cfg.model_name)
     parser.add_argument("--num_shots", type=int, default=cfg.num_shots)
-    parser.add_argument("--use_unsloth", action="store_true", default=cfg.use_unsloth)
+    parser.add_argument(
+        "--use_unsloth",
+        action=argparse.BooleanOptionalAction,
+        default=cfg.use_unsloth,
+        help="Enable Unsloth model loading (pass --no-use_unsloth to disable)",
+    )
     args = parser.parse_args()
 
     run(args.task, args.al_method, args.model_name, args.num_shots, args.use_unsloth)

--- a/docs/WALKTHROUGH.md
+++ b/docs/WALKTHROUGH.md
@@ -17,7 +17,7 @@ Use the requirements file provided with the main package:
 pip install -r active-ic-llm/requirements.txt
 ```
 
-Optional features such as the `unsloth` library can be installed if you plan on using the `--use_unsloth` flag during training.
+Optional features such as the `unsloth` library can be installed if you plan on using the `--use_unsloth` flag during training. You can disable these optimisations by passing `--no-use_unsloth`.
 
 ## 3. Download and prepare datasets
 


### PR DESCRIPTION
## Summary
- allow `--no-use_unsloth` on the experiment runner
- only load Unsloth when explicitly enabled
- document how to disable Unsloth in README and walkthrough

## Testing
- `python -m py_compile active-ic-llm/src/run_experiment.py active-ic-llm/src/models/model_utils.py`

------
https://chatgpt.com/codex/tasks/task_e_684a99dbace88320a9a2a8e2a360ec98