### PR TITLE
Remove Unsloth integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,6 @@ The code is organised as a Python package under `active-ic-llm` and contains scr
 
 See `active-ic-llm/README.md` for details on how to install dependencies, prepare data and reproduce the experiments.
 
-The codebase optionally integrates the [unsloth.ai](https://www.unsloth.ai) library
-for faster model loading when the `--use_unsloth` flag is supplied.
 
 Prepared datasets span multiple benchmarks including math reasoning
 (e.g. GSM8k, AQUA-RAT), commonsense QA (BoolQ, HellaSwag, ARC, Winogrande, PiQA
@@ -26,6 +24,18 @@ Edit the `TASK` and `MODE` constants inside the script and run:
 ```bash
 python scripts/calc_avg.py
 ```
+
+If you pass a filesystem path to `--model_name`, the loader reads the model
+directly from that directory without accessing the HuggingFace Hub.
+
+Embeddings required for diversity and similarity sampling use the
+`SentenceTransformer` library. Set the `SBERT_MODEL` environment variable to a
+local path if you wish to avoid downloading the default model.
+
+The code uses PyTorch exclusively. TensorFlow and JAX imports are disabled
+automatically by setting the `TRANSFORMERS_NO_TF_IMPORT` and
+`TRANSFORMERS_NO_FLAX_IMPORT` environment variables before loading
+`transformers`.
 
 
 ## Step-by-Step Walkthrough

--- a/active-ic-llm/README.md
+++ b/active-ic-llm/README.md
@@ -12,7 +12,6 @@ This directory contains the implementation of ActiveLLM. It is organised into se
 ```bash
 pip install -r requirements.txt
 ```
-To enable optional training and inference optimisations using [unsloth.ai](https://www.unsloth.ai), install the package and pass the `--use_unsloth` flag when running experiments. To avoid pulling heavy dependencies you may run `pip install --no-deps unsloth`.
 
 ## Preparing Data
 
@@ -37,6 +36,17 @@ python -m src.run_experiment --task sst2 --al_method random --model_name bert-ba
 Batch experiments for all tasks are available under `experiments/`.
 Outputs including per-example predictions and accuracy/F1 scores are written to the `outputs/` directory. The metrics file for a run can be found at `outputs/<task_type>/<task>/<model>/<al_method>/metrics.json`.
 To average metrics across multiple runs you can use `../scripts/aggregate_metrics.py`.
+
+If `--model_name` is a path on disk, the model will be loaded entirely from that
+directory without downloading files.
+
+For sampling strategies that rely on sentence embeddings, you can set the
+`SBERT_MODEL` environment variable to a local directory to load the embeddings
+model from disk.
+
+TensorFlow and JAX are disabled by default when importing `transformers`. The
+scripts set `TRANSFORMERS_NO_TF_IMPORT=1` and `TRANSFORMERS_NO_FLAX_IMPORT=1`
+before loading any HuggingFace models to ensure PyTorch-only execution.
 
 cd active-ic-llm
 python -m src.run_experiment --task gsm8k --al_method random --model_name llama-3.2-1b --num_shots 8

--- a/active-ic-llm/config.yaml
+++ b/active-ic-llm/config.yaml
@@ -49,4 +49,3 @@ outputs_dir: outputs
 max_seq_length: 128
 seed: 42
 device: gpu
-use_unsloth: true

--- a/active-ic-llm/requirements.txt
+++ b/active-ic-llm/requirements.txt
@@ -5,4 +5,3 @@ datasets
 scikit-learn
 pyyaml
 pandas
-unsloth  # optional speedups

--- a/active-ic-llm/src/models/model_utils.py
+++ b/active-ic-llm/src/models/model_utils.py
@@ -1,30 +1,28 @@
 """Wrapper utilities around HuggingFace causal language models."""
 
+import os
+os.environ.setdefault("TRANSFORMERS_NO_TF_IMPORT", "1")
+os.environ.setdefault("TRANSFORMERS_NO_FLAX_IMPORT", "1")
+
 from typing import List
+from pathlib import Path
 import torch
 from transformers import AutoTokenizer, AutoModelForCausalLM
-
-try:
-    from unsloth.models import FastLanguageModel
-    _HAS_UNSLOTH = True
-except Exception:
-    _HAS_UNSLOTH = False
 import math
 
 
 class ModelUtils:
-    def __init__(self, model_name: str, device: str = "cpu", use_unsloth: bool = False):
+    def __init__(self, model_name: str, device: str = "cpu"):
         self.device = device
-        if use_unsloth and _HAS_UNSLOTH:
-            self.model, self.tokenizer = FastLanguageModel.from_pretrained(
-                model_name,
-                device_map="auto",
-                use_gradient_checkpointing=False,
-            )
-            self.model = self.model.to(device)
-        else:
-            self.tokenizer = AutoTokenizer.from_pretrained(model_name)
-            self.model = AutoModelForCausalLM.from_pretrained(model_name).to(device)
+        # If the user provides a local path, avoid any network downloads by
+        # forcing HuggingFace to load files only from that directory.
+        local = Path(model_name).exists()
+        self.tokenizer = AutoTokenizer.from_pretrained(
+            model_name, local_files_only=local
+        )
+        self.model = AutoModelForCausalLM.from_pretrained(
+            model_name, local_files_only=local
+        ).to(device)
 
     def compute_perplexity(self, text: str) -> float:
         inputs = self.tokenizer(text, return_tensors="pt").to(self.device)

--- a/active-ic-llm/src/run_experiment.py
+++ b/active-ic-llm/src/run_experiment.py
@@ -1,5 +1,9 @@
 """Main experiment driver."""
 
+import os
+os.environ.setdefault("TRANSFORMERS_NO_TF_IMPORT", "1")
+os.environ.setdefault("TRANSFORMERS_NO_FLAX_IMPORT", "1")
+
 import argparse
 from typing import List, Dict
 import json
@@ -25,11 +29,11 @@ def get_sampler(name: str):
     raise ValueError(f"Unknown sampler {name}")
 
 
-def run(task: str, al_method: str, model_name: str, num_shots: int, use_unsloth: bool) -> None:
+def run(task: str, al_method: str, model_name: str, num_shots: int) -> None:
     pool_dataset = CrossFitDataset(task, "pool")
     test_dataset = CrossFitDataset(task, "test")
     sampler = get_sampler(al_method)
-    mu = ModelUtils(model_name, device=cfg.device, use_unsloth=use_unsloth)
+    mu = ModelUtils(model_name, device=cfg.device)
     label_space = sorted(set(pool_dataset.get_all_labels()))
 
     if al_method != "similarity":
@@ -92,10 +96,9 @@ def main():
     parser.add_argument("--al_method", default=cfg.al_method)
     parser.add_argument("--model_name", default=cfg.model_name)
     parser.add_argument("--num_shots", type=int, default=cfg.num_shots)
-    parser.add_argument("--use_unsloth", action="store_true", default=cfg.use_unsloth)
     args = parser.parse_args()
 
-    run(args.task, args.al_method, args.model_name, args.num_shots, args.use_unsloth)
+    run(args.task, args.al_method, args.model_name, args.num_shots)
 
 
 if __name__ == "__main__":

--- a/active-ic-llm/src/utils/embeddings.py
+++ b/active-ic-llm/src/utils/embeddings.py
@@ -1,12 +1,28 @@
 """Sentence embedding utilities using SentenceTransformer."""
 
+import os
+os.environ.setdefault("TRANSFORMERS_NO_TF_IMPORT", "1")
+os.environ.setdefault("TRANSFORMERS_NO_FLAX_IMPORT", "1")
+
 from typing import List
 import numpy as np
 from sentence_transformers import SentenceTransformer
+from pathlib import Path
 
-_sbert_model = SentenceTransformer("all-MiniLM-L6-v2")
+_sbert_model = None
+
+
+def _load_model() -> SentenceTransformer:
+    """Lazily load the sentence transformer to avoid unnecessary downloads."""
+    global _sbert_model
+    if _sbert_model is None:
+        model_name = os.environ.get("SBERT_MODEL", "all-MiniLM-L6-v2")
+        local = Path(model_name).exists()
+        _sbert_model = SentenceTransformer(model_name, local_files_only=local)
+    return _sbert_model
 
 
 def embed_texts(texts: List[str]) -> np.ndarray:
-    emb = _sbert_model.encode(texts, normalize_embeddings=True)
+    model = _load_model()
+    emb = model.encode(texts, normalize_embeddings=True)
     return np.array(emb)

--- a/docs/WALKTHROUGH.md
+++ b/docs/WALKTHROUGH.md
@@ -17,8 +17,6 @@ Use the requirements file provided with the main package:
 pip install -r active-ic-llm/requirements.txt
 ```
 
-Optional features such as the `unsloth` library can be installed if you plan on using the `--use_unsloth` flag during training.
-
 ## 3. Download and prepare datasets
 
 Run the preprocessing scripts to fetch and standardise datasets:
@@ -38,6 +36,14 @@ python -m src.run_experiment --task sst2 --al_method random --model_name bert-ba
 ```
 
 Outputs including predictions and metrics will be written under `outputs/<task_type>/<task>/<model>/<al_method>/`.
+
+If you provide a local directory to `--model_name`, the model is loaded from
+that path without contacting HuggingFace. You can also set the `SBERT_MODEL`
+environment variable to point to a local sentence transformer so that
+diversity/similarity sampling works offline.
+The code disables TensorFlow and JAX imports via
+`TRANSFORMERS_NO_TF_IMPORT=1` and `TRANSFORMERS_NO_FLAX_IMPORT=1` so only
+PyTorch components are used.
 
 ## 5. Aggregate metrics across runs (optional)
 


### PR DESCRIPTION
## Summary
- drop Unsloth-related options and imports
- clean docs and config of any references to Unsloth
- load models from disk without contacting HuggingFace when a local path is provided
- note in README that filesystem paths avoid downloads
- improve path detection when loading local models
- allow local loading of sentence-transformer embeddings using SBERT_MODEL env var
- disable TensorFlow/JAX imports via environment variables for PyTorch-only execution

## Testing
- `python -m py_compile active-ic-llm/src/run_experiment.py active-ic-llm/src/models/model_utils.py active-ic-llm/src/utils/embeddings.py`


------
https://chatgpt.com/codex/tasks/task_e_684a99dbace88320a9a2a8e2a360ec98