### PR TITLE
Enable multi-GPU inference and remove TensorFlow references

### DIFF
--- a/active-ic-llm/config.yaml
+++ b/active-ic-llm/config.yaml
@@ -49,3 +49,4 @@ outputs_dir: outputs
 max_seq_length: 128
 seed: 42
 device: cuda
+num_gpus: 4

--- a/active-ic-llm/src/al/uncertainty_sampling.py
+++ b/active-ic-llm/src/al/uncertainty_sampling.py
@@ -10,9 +10,10 @@ class UncertaintySampler:
     def __init__(self):
         self.model_name = cfg.model_name
         self.device = cfg.device
+        self.num_gpus = cfg.num_gpus
 
     def select(self, pool_dataset, k: int) -> List[int]:
         texts = pool_dataset.get_all_texts()
-        perplexities = compute_perplexities(texts, self.model_name, self.device)
+        perplexities = compute_perplexities(texts, self.model_name, self.device, self.num_gpus)
         ranked = sorted(range(len(texts)), key=lambda i: perplexities[i], reverse=True)
         return ranked[:k]

--- a/active-ic-llm/src/run_experiment.py
+++ b/active-ic-llm/src/run_experiment.py
@@ -29,7 +29,7 @@ def run(task: str, al_method: str, model_name: str, num_shots: int) -> None:
     pool_dataset = CrossFitDataset(task, "pool")
     test_dataset = CrossFitDataset(task, "test")
     sampler = get_sampler(al_method)
-    mu = ModelUtils(model_name, device=cfg.device)
+    mu = ModelUtils(model_name, device=cfg.device, num_gpus=cfg.num_gpus)
     label_space = sorted(set(pool_dataset.get_all_labels()))
 
     if al_method != "similarity":
@@ -92,7 +92,11 @@ def main():
     parser.add_argument("--al_method", default=cfg.al_method)
     parser.add_argument("--model_name", default=cfg.model_name)
     parser.add_argument("--num_shots", type=int, default=cfg.num_shots)
+    parser.add_argument("--num_gpus", type=int, default=cfg.num_gpus)
     args = parser.parse_args()
+
+    # Update config in case command-line overrides were provided
+    cfg.num_gpus = args.num_gpus
 
     run(args.task, args.al_method, args.model_name, args.num_shots)
 

--- a/active-ic-llm/src/utils/perplexity.py
+++ b/active-ic-llm/src/utils/perplexity.py
@@ -5,6 +5,6 @@ from typing import List
 from ..models.model_utils import ModelUtils
 
 
-def compute_perplexities(texts: List[str], model_name: str, device: str) -> List[float]:
-    mu = ModelUtils(model_name, device=device)
+def compute_perplexities(texts: List[str], model_name: str, device: str, num_gpus: int) -> List[float]:
+    mu = ModelUtils(model_name, device=device, num_gpus=num_gpus)
     return [mu.compute_perplexity(t) for t in texts]


### PR DESCRIPTION
## Summary
- drop environment variables related to TensorFlow detection
- add `num_gpus` option in `config.yaml`
- parallelize `ModelUtils` with `DataParallel` for multi‑GPU inference
- propagate `num_gpus` setting to utility functions and CLI

