### PR TITLE
Optimize perplexity computation

### DIFF
--- a/active-ic-llm/README.md
+++ b/active-ic-llm/README.md
@@ -31,6 +31,8 @@ Run the experiment module from within the `active-ic-llm` directory:
 ```bash
 cd active-ic-llm
 python -m src.run_experiment --task sst2 --al_method random --model_name bert-base-uncased --num_shots 8
+# Optionally control batching for perplexity-based sampling
+python -m src.run_experiment --task sst2 --al_method uncertainty --model_name bert-base-uncased --num_shots 8 --perplexity_batch_size 16
 ```
 
 Batch experiments for all tasks are available under `experiments/`.

--- a/active-ic-llm/config.yaml
+++ b/active-ic-llm/config.yaml
@@ -49,3 +49,5 @@ outputs_dir: outputs
 max_seq_length: 128
 seed: 42
 device: cuda
+num_gpus: 4
+perplexity_batch_size: 8

--- a/active-ic-llm/src/al/uncertainty_sampling.py
+++ b/active-ic-llm/src/al/uncertainty_sampling.py
@@ -10,9 +10,17 @@ class UncertaintySampler:
     def __init__(self):
         self.model_name = cfg.model_name
         self.device = cfg.device
+        self.num_gpus = cfg.num_gpus
+        self.batch_size = cfg.perplexity_batch_size
 
     def select(self, pool_dataset, k: int) -> List[int]:
         texts = pool_dataset.get_all_texts()
-        perplexities = compute_perplexities(texts, self.model_name, self.device)
+        perplexities = compute_perplexities(
+            texts,
+            self.model_name,
+            self.device,
+            self.num_gpus,
+            self.batch_size,
+        )
         ranked = sorted(range(len(texts)), key=lambda i: perplexities[i], reverse=True)
         return ranked[:k]

--- a/active-ic-llm/src/models/model_utils.py
+++ b/active-ic-llm/src/models/model_utils.py
@@ -5,6 +5,11 @@ from pathlib import Path
 
 import os
 
+# Prevent transformers from importing TensorFlow or Flax which slows down
+# startup and emits unwanted log messages.
+os.environ.setdefault("TRANSFORMERS_NO_TF_IMPORT", "1")
+os.environ.setdefault("TRANSFORMERS_NO_FLAX", "1")
+os.environ.setdefault("TF_CPP_MIN_LOG_LEVEL", "3")
 
 import torch
 from transformers import AutoTokenizer, AutoModelForCausalLM
@@ -12,8 +17,9 @@ import math
 
 
 class ModelUtils:
-    def __init__(self, model_name: str, device: str = "cpu"):
+    def __init__(self, model_name: str, device: str = "cpu", num_gpus: int = 1):
         self.device = device
+        self.num_gpus = num_gpus
 
         # If the user provides a local path, avoid any network downloads by
         # forcing HuggingFace to load files only from that directory.
@@ -24,7 +30,16 @@ class ModelUtils:
         )
         self.model = AutoModelForCausalLM.from_pretrained(
             model_name, local_files_only=local
-        ).to(device)
+        )
+
+        if device.startswith("cuda") and torch.cuda.is_available():
+            available = torch.cuda.device_count()
+            if available > 1:
+                gpus = list(range(min(self.num_gpus, available)))
+                self.model = torch.nn.DataParallel(self.model, device_ids=gpus)
+            torch.backends.cudnn.benchmark = True
+
+        self.model = self.model.to(device).eval()
 
 
     def compute_perplexity(self, text: str) -> float:
@@ -33,6 +48,31 @@ class ModelUtils:
             outputs = self.model(**inputs, labels=inputs["input_ids"])
             loss = outputs.loss
         return math.exp(loss.item())
+
+    def compute_batch_perplexity(self, texts: List[str], batch_size: int = 8) -> List[float]:
+        """Compute perplexities for a list of texts in batches."""
+        perplexities = []
+        for i in range(0, len(texts), batch_size):
+            batch = texts[i : i + batch_size]
+            enc = self.tokenizer(batch, return_tensors="pt", padding=True)
+            labels = enc["input_ids"].clone()
+            if self.tokenizer.pad_token_id is not None:
+                labels[labels == self.tokenizer.pad_token_id] = -100
+            enc = {k: v.to(self.device) for k, v in enc.items()}
+            with torch.no_grad():
+                logits = self.model(**enc, labels=labels.to(self.device)).logits
+            shift_logits = logits[:, :-1, :].contiguous()
+            shift_labels = labels[:, 1:].to(self.device)
+            loss_fct = torch.nn.CrossEntropyLoss(reduction="none")
+            losses = loss_fct(
+                shift_logits.view(-1, shift_logits.size(-1)),
+                shift_labels.view(-1),
+            )
+            losses = losses.view(shift_labels.size())
+            mask = shift_labels != -100
+            seq_loss = (losses * mask).sum(1) / mask.sum(1)
+            perplexities.extend(torch.exp(seq_loss).tolist())
+        return perplexities
 
     def _score_completion(self, text: str) -> float:
         inputs = self.tokenizer(text, return_tensors="pt").to(self.device)

--- a/active-ic-llm/src/run_experiment.py
+++ b/active-ic-llm/src/run_experiment.py
@@ -29,7 +29,7 @@ def run(task: str, al_method: str, model_name: str, num_shots: int) -> None:
     pool_dataset = CrossFitDataset(task, "pool")
     test_dataset = CrossFitDataset(task, "test")
     sampler = get_sampler(al_method)
-    mu = ModelUtils(model_name, device=cfg.device)
+    mu = ModelUtils(model_name, device=cfg.device, num_gpus=cfg.num_gpus)
     label_space = sorted(set(pool_dataset.get_all_labels()))
 
     if al_method != "similarity":
@@ -92,7 +92,17 @@ def main():
     parser.add_argument("--al_method", default=cfg.al_method)
     parser.add_argument("--model_name", default=cfg.model_name)
     parser.add_argument("--num_shots", type=int, default=cfg.num_shots)
+    parser.add_argument("--num_gpus", type=int, default=cfg.num_gpus)
+    parser.add_argument(
+        "--perplexity_batch_size",
+        type=int,
+        default=cfg.perplexity_batch_size,
+    )
     args = parser.parse_args()
+
+    # Update config in case command-line overrides were provided
+    cfg.num_gpus = args.num_gpus
+    cfg.perplexity_batch_size = args.perplexity_batch_size
 
     run(args.task, args.al_method, args.model_name, args.num_shots)
 

--- a/active-ic-llm/src/utils/perplexity.py
+++ b/active-ic-llm/src/utils/perplexity.py
@@ -5,6 +5,13 @@ from typing import List
 from ..models.model_utils import ModelUtils
 
 
-def compute_perplexities(texts: List[str], model_name: str, device: str) -> List[float]:
-    mu = ModelUtils(model_name, device=device)
-    return [mu.compute_perplexity(t) for t in texts]
+def compute_perplexities(
+    texts: List[str],
+    model_name: str,
+    device: str,
+    num_gpus: int,
+    batch_size: int,
+) -> List[float]:
+    """Compute perplexities for a list of texts using batched inference."""
+    mu = ModelUtils(model_name, device=device, num_gpus=num_gpus)
+    return mu.compute_batch_perplexity(texts, batch_size=batch_size)


### PR DESCRIPTION
## Summary
- disable TensorFlow imports in `ModelUtils`
- enable CuDNN benchmarking for GPU inference
- add batch perplexity computation and CLI option
- document new option and default batch size in config
