### PR TITLE
Optimize sampler performance

### DIFF
--- a/active-ic-llm/src/al/similarity_sampling.py
+++ b/active-ic-llm/src/al/similarity_sampling.py
@@ -6,11 +6,21 @@ from ..utils.embeddings import embed_texts
 
 
 class SimilaritySampler:
+    """Select demonstrations most similar to a given test instance."""
+
     def __init__(self):
-        pass
+        # Cache embeddings for datasets so we don't recompute them for every
+        # test example which drastically slows down inference.
+        self._pool_cache = {}
 
     def select_for_one_test(self, pool_dataset, test_text: str, k: int) -> List[int]:
-        pool_emb = embed_texts(pool_dataset.get_all_texts())
+        """Return indices of ``k`` pool examples most similar to ``test_text``."""
+
+        dataset_id = id(pool_dataset)
+        if dataset_id not in self._pool_cache:
+            self._pool_cache[dataset_id] = embed_texts(pool_dataset.get_all_texts())
+        pool_emb = self._pool_cache[dataset_id]
+
         test_emb = embed_texts([test_text])
         sims = np.dot(pool_emb, test_emb.T).squeeze()
         topk = np.argsort(-sims)[:k]

--- a/active-ic-llm/src/run_experiment_ddp.py
+++ b/active-ic-llm/src/run_experiment_ddp.py
@@ -68,7 +68,12 @@ def run(task: str, al_method: str, model_name: str, num_shots: int) -> None:
     label_space = sorted(set(pool_dataset.get_all_labels()))
 
     if al_method != "similarity":
-        demo_indices = sampler.select(pool_dataset, num_shots)
+        demo_indices = None
+        if rank == 0:
+            demo_indices = sampler.select(pool_dataset, num_shots)
+        obj_list = [demo_indices]
+        dist.broadcast_object_list(obj_list, src=0)
+        demo_indices = obj_list[0]
         demos = [pool_dataset[i] for i in demo_indices]
 
     results = []


### PR DESCRIPTION
## Summary
- cache pool embeddings in `SimilaritySampler`
- broadcast demonstration selection once in DDP mode

## Testing
- `python -m py_compile src/al/similarity_sampling.py src/run_experiment_ddp.py`


------
https://chatgpt.com/codex/tasks/task_e_684eb3df3c308320ae2cc58dd09fa21b