### PR TITLE
Expose inference batch size

### DIFF
--- a/active-ic-llm/README.md
+++ b/active-ic-llm/README.md
@@ -31,11 +31,14 @@ Run the experiment module from within the `active-ic-llm` directory:
 ```bash
 cd active-ic-llm
 python -m src.run_experiment --task sst2 --al_method random --model_name bert-base-uncased --num_shots 8
-# Optionally control batching for perplexity-based sampling and model inference
+# Optionally control batching for perplexity scoring and prediction
 python -m src.run_experiment --task sst2 --al_method uncertainty \
     --model_name bert-base-uncased --num_shots 8 \
+
     --perplexity_batch_size 16 --inference_batch_size 8
 ```
+The `--inference_batch_size` flag sets how many prompts are scored
+together when predicting labels or multiple choice answers.
 
 Batch experiments for all tasks are available under `experiments/`.
 Outputs including per-example predictions and accuracy/F1 scores are written to the `outputs/` directory. The metrics file for a run can be found at `outputs/<task_type>/<task>/<model>/<al_method>/metrics.json`.

--- a/active-ic-llm/src/models/model_utils.py
+++ b/active-ic-llm/src/models/model_utils.py
@@ -116,20 +116,26 @@ class ModelUtils:
         return scores
 
     def predict_classification_batch(
-        self, prompts: List[str], candidate_labels: List[str]
+        self,
+        prompts: List[str],
+        candidate_labels: List[str],
+        batch_size: int = 1,
     ) -> List[str]:
         """Predict labels for a batch of classification prompts."""
         all_prompts = []
         for p in prompts:
             all_prompts.extend([p + " " + lab for lab in candidate_labels])
 
-        scores = self._score_completion_batch(all_prompts)
+        scores = self._score_completion_batch(all_prompts, batch_size=batch_size)
         scores_tensor = torch.tensor(scores).view(len(prompts), len(candidate_labels))
         best = scores_tensor.argmax(dim=1).tolist()
         return [candidate_labels[i] for i in best]
 
     def predict_multichoice_batch(
-        self, prompts: List[str], choices_list: List[List[str]]
+        self,
+        prompts: List[str],
+        choices_list: List[List[str]],
+        batch_size: int = 1,
     ) -> List[str]:
         """Predict answers for a batch of multiple choice prompts."""
         letters = list("ABCDEFGHIJKLMNOPQRSTUVWXYZ")
@@ -141,7 +147,7 @@ class ModelUtils:
                 [p + f" {l}) {c}" for l, c in zip(letters, choices)]
             )
 
-        scores = self._score_completion_batch(all_prompts)
+        scores = self._score_completion_batch(all_prompts, batch_size=batch_size)
         preds = []
         idx = 0
         for num_choices in offsets:

--- a/active-ic-llm/src/run_experiment.py
+++ b/active-ic-llm/src/run_experiment.py
@@ -68,9 +68,13 @@ def run(task: str, al_method: str, model_name: str, num_shots: int) -> None:
                 golds.append(gold)
 
         if classification:
-            preds = mu.predict_classification_batch(prompts, label_space)
+            preds = mu.predict_classification_batch(
+                prompts, label_space, batch_size=batch_size
+            )
         else:
-            preds = mu.predict_multichoice_batch(prompts, choices_list)
+            preds = mu.predict_multichoice_batch(
+                prompts, choices_list, batch_size=batch_size
+            )
 
         for p, g in zip(preds, golds):
             results.append({"prediction": p, "gold": g, "correct": p == g})

--- a/active-ic-llm/src/run_experiment_ddp.py
+++ b/active-ic-llm/src/run_experiment_ddp.py
@@ -109,9 +109,13 @@ def run(task: str, al_method: str, model_name: str, num_shots: int) -> None:
                 golds.append(gold)
 
         if classification:
-            preds = mu.predict_classification_batch(prompts, label_space)
+            preds = mu.predict_classification_batch(
+                prompts, label_space, batch_size=batch_size
+            )
         else:
-            preds = mu.predict_multichoice_batch(prompts, choices_list)
+            preds = mu.predict_multichoice_batch(
+                prompts, choices_list, batch_size=batch_size
+            )
 
         for idx, p, g in zip(batch_ids, preds, golds):
             results.append({"id": idx, "prediction": p, "gold": g, "correct": p == g})


### PR DESCRIPTION
## Summary
- allow batching in classification/multichoice helpers
- pass configured batch size in run scripts
- document inference batching in README

## Testing
- `python -m py_compile active-ic-llm/src/models/model_utils.py active-ic-llm/src/run_experiment.py active-ic-llm/src/run_experiment_ddp.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f6573e9ec832082ded9b429181e1a